### PR TITLE
Enabling jumbo frames.

### DIFF
--- a/etc_ansible/group_vars/all/vars_file.yml
+++ b/etc_ansible/group_vars/all/vars_file.yml
@@ -10,6 +10,7 @@ relational_database_driver:
 # vxlan with physical servers
 # openvswitch with appliance
 network_type: openvswitch
+network_mtu: 9000
 
 controller_hostname: openstack-vcenter
 rabbitmq_user: openstack
@@ -53,8 +54,8 @@ glance_dbpass: GLANCE_DBPASS
 keystone_glance_name: glance
 keystone_glance_password: glance
 
-glance_storage: file
-#glance_storage: rbd
+#glance_storage: file
+glance_storage: rbd
 rbd_parameters:
   rbd_store_pool: images
   rbd_store_user: glance

--- a/etc_ansible/roles/kvm-hypervisor/templates/ml2_conf.ini.j2
+++ b/etc_ansible/roles/kvm-hypervisor/templates/ml2_conf.ini.j2
@@ -132,6 +132,7 @@ mechanism_drivers = openvswitch
 # and instances typically default to a 1500 MTU. Only impacts instances, not
 # neutron network components such as bridges and routers. (integer value)
 #path_mtu = 1500
+path_mtu = {{ network_mtu }}
 
 # A list of mappings of physical networks to MTU values. The format of the
 # mapping is <physnet>:<mtu val>. This mapping allows specifying a physical

--- a/etc_ansible/roles/kvm-hypervisor/templates/neutron.conf.j2
+++ b/etc_ansible/roles/kvm-hypervisor/templates/neutron.conf.j2
@@ -170,6 +170,7 @@ service_plugins = router
 # value. Defaults to 1500, the standard value for Ethernet. (integer value)
 # Deprecated group/name - [ml2]/segment_mtu
 #global_physnet_mtu = 1500
+global_physnet_mtu = {{ network_mtu }}
 
 # Number of backlog requests to configure the socket with (integer value)
 #backlog = 4096

--- a/etc_ansible/roles/networking-compute-controller/templates/ml2_conf.ini.j2
+++ b/etc_ansible/roles/networking-compute-controller/templates/ml2_conf.ini.j2
@@ -135,6 +135,7 @@ extension_drivers = port_security
 # and instances typically default to a 1500 MTU. Only impacts instances, not
 # neutron network components such as bridges and routers. (integer value)
 #path_mtu = 1500
+path_mtu = {{ network_mtu }}
 
 # A list of mappings of physical networks to MTU values. The format of the
 # mapping is <physnet>:<mtu val>. This mapping allows specifying a physical

--- a/etc_ansible/roles/networking-compute-controller/templates/neutron.conf.j2
+++ b/etc_ansible/roles/networking-compute-controller/templates/neutron.conf.j2
@@ -171,6 +171,7 @@ notify_nova_on_port_data_changes = true
 # value. Defaults to 1500, the standard value for Ethernet. (integer value)
 # Deprecated group/name - [ml2]/segment_mtu
 #global_physnet_mtu = 1500
+global_physnet_mtu = {{ network_mtu }}
 
 # Number of backlog requests to configure the socket with (integer value)
 #backlog = 4096


### PR DESCRIPTION
This does not work with dockers default installation because docker0 starts with a 1500 MTU.
TODO: Configure dhcp server to send MTU to virtual machines.